### PR TITLE
Add dependency "gen" to opam

### DIFF
--- a/opam
+++ b/opam
@@ -29,4 +29,5 @@ depends: [
   "uri"
   "re" {>= "1.4.0"}
   "oasis" {dev & build}
+  "gen"
 ]


### PR DESCRIPTION
Furl seems to depend on gen. At least it didn't install for me until I added "gen". I don't know if there should be any version constraint.
